### PR TITLE
Add student's lesson logic

### DIFF
--- a/accounts_app/templates/accounts_app/instructor_profile.html
+++ b/accounts_app/templates/accounts_app/instructor_profile.html
@@ -1,0 +1,85 @@
+{% extends 'accounts_app/base.html' %}
+{% load static %}
+{% block title %}{{ instructor.username }}のプロフィール | スノトラ{% endblock %}
+
+{% block content %}
+<div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-2xl">
+    <div class="bg-white p-6 rounded-lg shadow-xl border border-gray-200 space-y-6">
+
+        <!-- 画像・名前 -->
+        <div class="flex items-center space-x-4">
+            {% if instructor.profile_image %}
+                <img src="{{ instructor.profile_image.url }}"
+                     class="w-20 h-20 rounded-full object-cover border border-gray-300"
+                     alt="{{ instructor.username }}">
+            {% else %}
+                <div class="w-20 h-20 rounded-full bg-gray-200 flex items-center justify-center text-gray-400 text-3xl">
+                    ?
+                </div>
+            {% endif %}
+            <div>
+                <h1 class="text-2xl font-extrabold text-gray-800">{{ instructor.username }}</h1>
+                <p class="text-sm text-gray-500">インストラクター</p>
+            </div>
+        </div>
+
+        {% if profile %}
+            <!-- 自己紹介 -->
+            {% if profile.self_introduction %}
+            <div>
+                <h2 class="text-base font-semibold text-gray-700 mb-1">自己紹介</h2>
+                <p class="text-gray-700 whitespace-pre-line">{{ profile.self_introduction }}</p>
+            </div>
+            {% endif %}
+
+            <!-- レッスン可能種目 -->
+            <div>
+                <h2 class="text-base font-semibold text-gray-700 mb-1">レッスン可能種目</h2>
+                <div class="flex space-x-3">
+                    {% if profile.skill_ski %}
+                        <span class="px-3 py-1 bg-sky-100 text-sky-700 rounded-full text-sm">スキー</span>
+                    {% endif %}
+                    {% if profile.skill_snowboard %}
+                        <span class="px-3 py-1 bg-sky-100 text-sky-700 rounded-full text-sm">スノーボード</span>
+                    {% endif %}
+                    {% if not profile.skill_ski and not profile.skill_snowboard %}
+                        <span class="text-gray-400 text-sm">未設定</span>
+                    {% endif %}
+                </div>
+            </div>
+
+            <!-- 対応言語 -->
+            <div>
+                <h2 class="text-base font-semibold text-gray-700 mb-1">対応言語</h2>
+                <div class="flex flex-wrap gap-2">
+                    {% if profile.spoken_japanese %}
+                        <span class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-sm">日本語</span>
+                    {% endif %}
+                    {% if profile.spoken_english %}
+                        <span class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-sm">英語</span>
+                    {% endif %}
+                    {% if profile.spoken_chinese %}
+                        <span class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-sm">中国語</span>
+                    {% endif %}
+                    {% if profile.spoken_other %}
+                        <span class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-sm">{{ profile.spoken_other }}</span>
+                    {% endif %}
+                    {% if not profile.spoken_japanese and not profile.spoken_english and not profile.spoken_chinese and not profile.spoken_other %}
+                        <span class="text-gray-400 text-sm">未設定</span>
+                    {% endif %}
+                </div>
+            </div>
+        {% else %}
+            <p class="text-gray-400 text-sm">プロフィールはまだ登録されていません。</p>
+        {% endif %}
+    </div>
+
+    <!-- 戻るボタン -->
+    <div class="mt-6">
+        <a href="{{ back_url }}"
+           class="inline-flex items-center text-sm text-sky-600 hover:underline">
+            ← 前のページに戻る
+        </a>
+    </div>
+</div>
+{% endblock %}

--- a/accounts_app/urls.py
+++ b/accounts_app/urls.py
@@ -18,6 +18,9 @@ urlpatterns = [
     # ユーザー設定 - 受講者 - インストラクター
     path('student_setting/', views.student_setting, name="student_setting"),
     path('instructor_setting/', views.instructor_setting, name="instructor_setting"),
+    # インストラクタープロフィール（公開）
+    path('instructor/<int:user_id>/profile/', views.instructor_profile_view, name='instructor_profile'),
+
     # メール認証
     path('signup/done/', views.signup_done_view, name='signup_done'),
     path('activate/<str:token>/', views.activate_view, name='activate'),

--- a/accounts_app/views.py
+++ b/accounts_app/views.py
@@ -6,7 +6,7 @@ from django.contrib.auth import authenticate, login, logout, update_session_auth
 from django.contrib.auth.decorators import login_required
 from django.core import signing
 from django.core.mail import send_mail
-from django.shortcuts import redirect, render
+from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from .forms import InstructorProfileForm, SignupForm, CustomPasswordChangeForm, LoginForm, UserUpdateForm
 from .models import CustomUser, InstructorProfile
@@ -74,6 +74,19 @@ def instructor_signup_view(request):
     else:
         signup_form = SignupForm()
     return render(request, 'accounts_app/instructor_signup.html', {'signup_form': signup_form})
+
+def instructor_profile_view(request, user_id):
+    instructor = get_object_or_404(CustomUser, id=user_id, role=CustomUser.Role.INSTRUCTOR)
+    try:
+        profile = instructor.instructor_profile
+    except InstructorProfile.DoesNotExist:
+        profile = None
+    back_url = request.META.get('HTTP_REFERER', '/')
+    return render(request, 'accounts_app/instructor_profile.html', {
+        'instructor': instructor,
+        'profile': profile,
+        'back_url': back_url,
+    })
 
 def signup_done_view(request):
     return render(request, 'accounts_app/signup_done.html')

--- a/dashboard_app/templates/dashboard_app/instructor_schedule.html
+++ b/dashboard_app/templates/dashboard_app/instructor_schedule.html
@@ -6,6 +6,14 @@
 <h1 class="text-center text-2xl sm:text-3xl font-extrabold text-gray-800 mt-2 mb-6 sm:mb-8">レッスン詳細編集</h1>
 <div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-3xl">
     <div class="bg-white p-6 rounded-lg shadow-xl border border-gray-200">
+        {% if not profile_complete %}
+        <div class="mb-6 p-4 bg-yellow-50 border border-yellow-300 rounded-md">
+            <p class="text-yellow-800 text-sm">
+                レッスン登録する際は、プロフィールを埋めてください。
+                <a href="{% url 'instructor_setting' %}" class="underline font-semibold">プロフィールを入力する</a>
+            </p>
+        </div>
+        {% endif %}
         <form method="post" action="{% url 'instructor_schedule' %}" class="space-y-6">
             {% csrf_token %}
             <div>
@@ -93,10 +101,12 @@
             <div class="pt-8 flex space-x-4">
                 <button
                 type="submit"
+                {% if not profile_complete %}disabled{% endif %}
                 class="flex w-full justify-center py-3 px-4 border border-transparent rounded-md
-                    shadow-sm text-base font-bold text-white bg-sky-600
-                    hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-500
-                    transition duration-300 ease-in-out cursor-pointer">
+                    shadow-sm text-base font-bold text-white
+                    {% if profile_complete %}bg-sky-600 hover:bg-sky-700 cursor-pointer{% else %}bg-gray-400 cursor-not-allowed{% endif %}
+                    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-500
+                    transition duration-300 ease-in-out">
                     保存する
                 </button>
             </div>

--- a/dashboard_app/templates/dashboard_app/lesson_search.html
+++ b/dashboard_app/templates/dashboard_app/lesson_search.html
@@ -158,7 +158,12 @@
                             <dt class="font-semibold text-gray-700">時間帯</dt>
                             <dd class="text-gray-900">{{ lesson.time_slot_display_ja }}</dd>
                             <dt class="font-semibold text-gray-700">担当インストラクター</dt>
-                            <dd class="text-gray-900">{{ lesson.instructor.username }}</dd>
+                            <dd class="text-gray-900">
+                                <a href="{% url 'instructor_profile' lesson.instructor.id %}"
+                                   class="text-sky-600 hover:underline">
+                                    {{ lesson.instructor.username }}
+                                </a>
+                            </dd>
                             <dt class="font-semibold text-gray-700">料金</dt>
                             <dd class="text-gray-900">¥ {{ lesson.price|intcomma }}</dd>
                         </dl>

--- a/dashboard_app/views.py
+++ b/dashboard_app/views.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from .forms import LessonDetailForm, LessonSearchForm
+from accounts_app.models import InstructorProfile
 from .models import ActivityChoices, LessonDetail, LessonPreference, SkiResort
 import stripe
 
@@ -69,22 +70,37 @@ def instructor_dashboard_view(request):
         }
     )
 
+def _is_profile_complete(user):
+    """プロフィールの必須項目（自己紹介・種目いずれか）が入力済みか確認する。"""
+    try:
+        profile = user.instructor_profile
+    except InstructorProfile.DoesNotExist:
+        return False
+    return bool(profile.self_introduction) and (profile.skill_ski or profile.skill_snowboard)
+
 @login_required
 def instructor_schedule(request):
     if not request.user.is_instructor:
         return error_response(request, 'インストラクターのみアクセス可能です。')
 
+    profile_complete = _is_profile_complete(request.user)
+
     if request.method == 'POST':
+        if not profile_complete:
+            return error_response(request, 'レッスンを登録するには、先にプロフィールを入力してください。', status=403)
         form = LessonDetailForm(request.POST)
         if form.is_valid():
             lesson_detail = form.save(commit=False)
             lesson_detail.instructor = request.user
             lesson_detail.save()
-            return redirect('instructor_schedule')  # 登録後リダイレクト
+            return redirect('instructor_schedule')
     else:
         form = LessonDetailForm()
 
-    return render(request, 'dashboard_app/instructor_schedule.html', {'form': form})
+    return render(request, 'dashboard_app/instructor_schedule.html', {
+        'form': form,
+        'profile_complete': profile_complete,
+    })
 
 # フロントの都道府県選択に応じて対応するスキー場を返すAjaxエンドポイント
 @login_required


### PR DESCRIPTION
受講生から担当インストラクターがどんな人なのかを見れるように修正しました。

<img width="775" height="473" alt="Screenshot 2026-04-23 at 19 07 05" src="https://github.com/user-attachments/assets/45d3ed04-8369-43c3-a960-a42196343e84" />
レッスン応募から、担当インストラクターの部分を選択すると詳細が見れる。

<img width="930" height="611" alt="Screenshot 2026-04-23 at 19 06 36" src="https://github.com/user-attachments/assets/84b88b24-f355-4835-81cf-041b5d69dd40" />
実際の詳細画面。現在は、詳細が書かれていないが、インストラクター側でプロフィール項目が埋まっていない状態で、レッスン登録できないようにした。
そのため、今後は受講者が担当インストラクターの詳細は明確にわかるようになっている想定だ。
