### PR TITLE
fix: instructor profile' password form

### DIFF
--- a/accounts_app/views.py
+++ b/accounts_app/views.py
@@ -231,30 +231,30 @@ def instructor_setting(request):
 
     # 「更新ボタン」が押された時
     if request.method == 'POST':
-        # フォームのインスタンス化(POSTデータと既存のインスタンスを紐付け)
         user_form = UserUpdateForm(request.POST, instance=request.user)
         password_form = CustomPasswordChangeForm(user=request.user, data=request.POST)
         instructor_profile_form = InstructorProfileForm(request.POST, instance=instructor_profile)
 
-        # 各フォームのバリデーション結果
         user_valid = user_form.is_valid()
-        password_valid = password_form.is_valid()
         instructor_profile_valid = instructor_profile_form.is_valid()
 
-        # 全てのフォームが有効であれば保存処理をする
+        password_fields_filled = any([
+            request.POST.get('old_password'),
+            request.POST.get('new_password1'),
+            request.POST.get('new_password2'),
+        ])
+        password_valid = password_form.is_valid() if password_fields_filled else True
+
         if user_valid and password_valid and instructor_profile_valid:
             user_form.save()
-            password_form.save()
             instructor_profile_form.save()
-
-            #パスワード変更後にログアウトされるのを防ぐ
-            update_session_auth_hash(request, password_form.user)
+            if password_fields_filled:
+                password_form.save()
+                update_session_auth_hash(request, password_form.user)
             messages.success(request, 'ユーザー情報を更新しました')
             return redirect('instructor_setting')
         else:
-            # フォームのどこかにエラーがあればメッセージを表示させる
             messages.error(request, '入力内容に誤りがあります。確認してください')
-            # エラーがある場合でも、フォームインスタンスを渡してエラーメッセージを表示させる
             params = {
                 'user_form': user_form,
                 'password_form': password_form,

--- a/dashboard_app/templates/dashboard_app/lesson_search.html
+++ b/dashboard_app/templates/dashboard_app/lesson_search.html
@@ -141,7 +141,14 @@
             </h2>
             <div class="space-y-4">
                 {% for lesson in lessons %}
-                    <div class="p-4 border rounded shadow-sm">
+                    <div class="p-4 border rounded shadow-sm {% if lesson.is_full %}opacity-60{% endif %}">
+                        {% if lesson.is_full %}
+                        <div class="mb-3">
+                            <span class="inline-block px-3 py-1 bg-gray-500 text-white text-xs font-bold rounded-full tracking-widest">
+                                SOLD OUT
+                            </span>
+                        </div>
+                        {% endif %}
                         <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-2">
                             <dt class="font-semibold text-gray-700">レッスン日</dt>
                             <dd class="text-gray-900">{{ lesson.lesson_date|date:"Y年m月d日" }}</dd>
@@ -168,14 +175,21 @@
                             <dd class="text-gray-900">¥ {{ lesson.price|intcomma }}</dd>
                         </dl>
                         <div class="flex justify-end mt-4">
-                            <form method="POST" action="{% url 'lesson_confirm' lesson.id %}">
-                                {% csrf_token %}
-                                <button type="submit"
-                                    class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
-                                    aria-label="このレッスンを予約する">
-                                    このレッスンを予約する
+                            {% if lesson.is_full %}
+                                <button type="button" disabled
+                                    class="px-4 py-2 bg-gray-400 text-white rounded cursor-not-allowed">
+                                    予約できません
                                 </button>
-                            </form>
+                            {% else %}
+                                <form method="POST" action="{% url 'lesson_confirm' lesson.id %}">
+                                    {% csrf_token %}
+                                    <button type="submit"
+                                        class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+                                        aria-label="このレッスンを予約する">
+                                        このレッスンを予約する
+                                    </button>
+                                </form>
+                            {% endif %}
                         </div>
                     </div>
                 {% endfor %}

--- a/dashboard_app/views.py
+++ b/dashboard_app/views.py
@@ -156,9 +156,10 @@ def lesson_search(request):
     lessons = LessonDetail.objects.none()  # デフォルトは空
 
     if form.is_valid():
+        today = timezone.localtime().date()
         lessons = LessonDetail.objects.select_related(
             "activity_type", "instructor", "prefecture", "ski_resort"
-        )
+        ).filter(lesson_date__gte=today)
 
         cd = form.cleaned_data
         if cd.get('lesson_date'):
@@ -178,6 +179,8 @@ def lesson_search(request):
 
         for lesson in lessons:
             lesson.price = get_lesson_price(lesson)
+            reserved_count = LessonPreference.objects.filter(lesson_detail=lesson).count()
+            lesson.is_full = reserved_count >= lesson.max_students
 
     return render(
         request,


### PR DESCRIPTION
インストラクターのパスワード更新ロジックを受講者と同じように合わせた。

受講者は過去のレッスン募集を見れるが、応募できないように設定した。
<img width="814" height="560" alt="Screenshot 2026-04-23 at 21 54 19" src="https://github.com/user-attachments/assets/cf01a75d-9def-477b-a565-9e6ad9ca0693" />
